### PR TITLE
`nyc` should be in devDependencies instead of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "eslint-config-rem": "^3.2.0",
+    "nyc": "^11.3.0",
     "rollup": "^0.51.5",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-json": "^2.3.0",
@@ -65,7 +66,6 @@
     ]
   },
   "dependencies": {
-    "lodash-es": "^4.17.4",
-    "nyc": "^11.3.0"
+    "lodash-es": "^4.17.4"
   }
 }


### PR DESCRIPTION
I noticed that `nyc` was only used for test coverage reporting, not within module code itself.